### PR TITLE
Fix the obsolete option of bedtools, and change the separation process for each strand

### DIFF
--- a/scripts/bidir_enhancers
+++ b/scripts/bidir_enhancers
@@ -132,6 +132,9 @@ fi
 
 if [ "$TCS" != "" ]; then
 	cut -f -6 $TCS | sort -k 1,1 -k 2,2n --temporary-directory=${TEMP} > ${TEMP}${STUB}TCs.bed
+    echoerr "Identifying bidirectionally transcribed loci"
+    TCFILE=${TEMP}${STUB}TCs.bed
+    ${BINDIR}/split_strand.pl $TCFILE ${TEMP}${STUB}TCs.plus.bed ${TEMP}${STUB}TCs.minus.bed
 fi
 
 ## Identify tag clusters, if needed
@@ -157,8 +160,9 @@ if [ "$TCS" == "" ]; then
 fi
 
 ## Identify bidirectional transcribed loci
-echoerr "Identifying bidirectionally transcribed loci"
-#${BINDIR}/split_strand.pl $TCFILE ${TEMP}${STUB}TCs.plus.bed ${TEMP}${STUB}TCs.minus.bed
+#echoerr "Identifying bidirectionally transcribed loci"
+#    ${BINDIR}/split_strand.pl $TCFILE ${TEMP}${STUB}TCs.plus.bed ${TEMP}${STUB}TCs.minus.bed
+
 
 bedtools intersect -v -wa -a ${TEMP}${STUB}TCs.plus.bed -b ${TEMP}${STUB}TCs.minus.bed > ${TEMP}${STUB}TCs.plus.no.minus.bed
 bedtools intersect -v -wa -b ${TEMP}${STUB}TCs.plus.bed -a ${TEMP}${STUB}TCs.minus.bed > ${TEMP}${STUB}TCs.minus.no.plus.bed

--- a/scripts/bidir_enhancers
+++ b/scripts/bidir_enhancers
@@ -151,10 +151,10 @@ if [ "$TCS" == "" ]; then
 		| awk 'BEGIN{OFS="\t"}{print $1, $2, $3, NR, $5, $4}' > $MBED
 
 	bedtools merge -d 20 -S + -i $MBED -o sum -c 5\
-		| awk 'BEGIN{OFS="\t"}{if ($4 > 1) {print $1, $2, $3, $1 ":" $2 "-" $3 ",+" $5, $4,"+"}}' \
+		| awk 'BEGIN{OFS="\t"}{if ($4 > 1) {print $1, $2, $3, $1 ":" $2 "-" $3 ",+", $4,"+"}}' \
 		| sort --temporary-directory=${TEMP} -k 1,1 -k 2,2n > ${TEMP}${STUB}TCs.plus.bed
 	bedtools merge -d 20 -S - -i $MBED -o sum -c 5\
-		| awk 'BEGIN{OFS="\t"}{if ($4 > 1) {print $1, $2, $3, $1 ":" $2 "-" $3 ",-" $5, $4,"+"}}' \
+		| awk 'BEGIN{OFS="\t"}{if ($4 > 1) {print $1, $2, $3, $1 ":" $2 "-" $3 ",-", $4,"-"}}' \
 		| sort --temporary-directory=${TEMP} -k 1,1 -k 2,2n > ${TEMP}${STUB}TCs.minus.bed
 
 fi

--- a/scripts/bidir_enhancers
+++ b/scripts/bidir_enhancers
@@ -40,7 +40,7 @@ usage() {
 	echoerr "  Used for identifying transcribed enhancers across FANTOM5 samples in"
 	echoerr "  Andersson R et al. 2014. An atlas of active enhancers across human cell types"
 	echoerr "  and tissues. Nature. doi:10.1038/nature12787"
-	echoerr
+	echoerr "  Modified by Masaki Suimye Morioka (update:2021.3) for adapting recent bedtools versions (v.2.92.0 and 2.30.0)"
 	echoerr "Usage:"
 	echoerr "  ${0##/} OPTIONS -f FILE -o PATH"
 	echoerr

--- a/scripts/bidir_enhancers
+++ b/scripts/bidir_enhancers
@@ -133,7 +133,6 @@ fi
 if [ "$TCS" != "" ]; then
 	cut -f -6 $TCS | sort -k 1,1 -k 2,2n --temporary-directory=${TEMP} > ${TEMP}${STUB}TCs.bed
 fi
-TCFILE=${TEMP}${STUB}TCs.bed
 
 ## Identify tag clusters, if needed
 ## Note: The Andersson et al. (2014) study used DPI tag clusters described in Forrest A et al. 2014. Nature. (doi:10.1038/nature13182).
@@ -144,21 +143,30 @@ if [ "$TCS" == "" ]; then
 	if [ -e $BED ]; then rm $BED; fi
 	touch $BED
 	for FILE in $( cat $FILES ); do cat $FILE >> $BED; done
-	sort --temporary-directory=${TEMP} -k 1,1 -k 2,2n -k 3,3n -k 6,6 $BED | bedtools groupby -i stdin -g 1,2,3,6 -c 5 -o sum | awk 'BEGIN{OFS="\t"}{print $1, $2, $3, NR, $5, $4}' > $MBED
-	bedtools merge -d 20 -s -i $MBED -scores sum | awk 'BEGIN{OFS="\t"}{if ($4 > 1) {print $1, $2, $3, $1 ":" $2 "-" $3 "," $5, $4, $5}}' | sort --temporary-directory=${TEMP} -k 1,1 -k 2,2n > ${OPATH}${STUB}TCs.bed
-	TCFILE=${OPATH}${STUB}TCs.bed
+	sort --temporary-directory=${TEMP} -k 1,1 -k 2,2n -k 3,3n -k 6,6 $BED \
+		| bedtools groupby -i stdin -g 1,2,3,6 -c 5 -o sum \
+		| awk 'BEGIN{OFS="\t"}{print $1, $2, $3, NR, $5, $4}' > $MBED
+
+	bedtools merge -d 20 -S + -i $MBED -o sum -c 5\
+		| awk 'BEGIN{OFS="\t"}{if ($4 > 1) {print $1, $2, $3, $1 ":" $2 "-" $3 ",+" $5, $4,"+"}}' \
+		| sort --temporary-directory=${TEMP} -k 1,1 -k 2,2n > ${TEMP}${STUB}TCs.plus.bed
+	bedtools merge -d 20 -S - -i $MBED -o sum -c 5\
+		| awk 'BEGIN{OFS="\t"}{if ($4 > 1) {print $1, $2, $3, $1 ":" $2 "-" $3 ",-" $5, $4,"+"}}' \
+		| sort --temporary-directory=${TEMP} -k 1,1 -k 2,2n > ${TEMP}${STUB}TCs.minus.bed
+
 fi
 
 ## Identify bidirectional transcribed loci
 echoerr "Identifying bidirectionally transcribed loci"
-${BINDIR}/split_strand.pl $TCFILE ${TEMP}${STUB}TCs.plus.bed ${TEMP}${STUB}TCs.minus.bed
+#${BINDIR}/split_strand.pl $TCFILE ${TEMP}${STUB}TCs.plus.bed ${TEMP}${STUB}TCs.minus.bed
 
 bedtools intersect -v -wa -a ${TEMP}${STUB}TCs.plus.bed -b ${TEMP}${STUB}TCs.minus.bed > ${TEMP}${STUB}TCs.plus.no.minus.bed
 bedtools intersect -v -wa -b ${TEMP}${STUB}TCs.plus.bed -a ${TEMP}${STUB}TCs.minus.bed > ${TEMP}${STUB}TCs.minus.no.plus.bed
 bedtools window -l 0 -r $DIST -a ${TEMP}${STUB}TCs.minus.no.plus.bed -b ${TEMP}${STUB}TCs.plus.no.minus.bed | awk 'BEGIN{OFS="\t"}{print $0, $3-$8}' > ${TEMP}${STUB}TCs.bidir.pairs.bed
 sort --temporary-directory=${TEMP} -k 1,1 -k 2,2n -o ${TEMP}${STUB}TCs.bidir.pairs.bed ${TEMP}${STUB}TCs.bidir.pairs.bed
 ## Merge pairs and discard bidirectional transcribed loci too close to chromosome starts
-${BINDIR}/bed12_merge_pairs_dynamic.pl ${TEMP}${STUB}TCs.bidir.pairs.bed | awk -v win=$WIN 'BEGIN{OFS="\t"}{if (($7-win) >= 0) {print $1, $2, $3, $1 ":" $2 "-" $3, $5, $6, $7, $8, $9, $10, $11, $12}}' > ${OPATH}${STUB}bidir.pairs.bed
+${BINDIR}/bed12_merge_pairs_dynamic.pl ${TEMP}${STUB}TCs.bidir.pairs.bed \
+	| awk -v win=$WIN 'BEGIN{OFS="\t"}{if (($7-win) >= 0) {print $1, $2, $3, $1 ":" $2 "-" $3, $5, $6, $7, $8, $9, $10, $11, $12}}' > ${OPATH}${STUB}bidir.pairs.bed
 
 BPS=${OPATH}${STUB}bidir.pairs.bed
 
@@ -194,7 +202,12 @@ for FILE in $( cat $FILES ); do
 	echo $CNT >> $LIBRARYCOUNTS
 	for SIDE in left right; do
 		for STRAND in plus minus; do
-			bedtools intersect -wao -s -a ${TEMP}${ESTUB}.${SIDE}.${STRAND}.window.bed -b $FILE | sort --temporary-directory=${TEMP} -k 1,1 -k 2,2n | cut -f 1,2,3,4,5,6,11 | awk 'BEGIN{OFS="\t"} {v = $7; if (v <= 0) v = 0; print $1,$2,$3,$4,$5,$6,v}' | bedtools groupby -g 1,2,3,4,5,6 -c 7 -o sum | sort --temporary-directory=${TEMP} -k 1,1 -k 2,2n | cut -f 7 > ${TEMP}${ESTUB}.expression.${SIDE}.${STRAND}.tmp &
+			bedtools intersect -wao -s -a ${TEMP}${ESTUB}.${SIDE}.${STRAND}.window.bed -b $FILE \
+				| sort --temporary-directory=${TEMP} -k 1,1 -k 2,2n | cut -f 1,2,3,4,5,6,11 \
+				| awk 'BEGIN{OFS="\t"} {v = $7; if (v <= 0) v = 0; print $1,$2,$3,$4,$5,$6,v}' \
+				| bedtools groupby -g 1,2,3,4,5,6 -c 7 -o sum \
+				| sort --temporary-directory=${TEMP} -k 1,1 -k 2,2n \
+				| cut -f 7 > ${TEMP}${ESTUB}.expression.${SIDE}.${STRAND}.tmp &
 		done
 		wait
 		for STRAND in plus minus; do
@@ -212,12 +225,16 @@ ${BINDIR}/sum_matrices.pl ${TEMP}${ESTUB}.expression.left.minus.matrix ${TEMP}${
 
 ## TPM normalize
 echoerr "Normalizing expression to tags per million mapped tags (TPM)"
-${BINDIR}/tpm_transform.pl ${OPATH}${ESTUB}.expression.matrix ${LIBRARYCOUNTS} 1 | paste $BPS - | cut -f 4,13- > ${OPATH}${ESTUB}.expression.tpm.matrix
+${BINDIR}/tpm_transform.pl ${OPATH}${ESTUB}.expression.matrix ${LIBRARYCOUNTS} 1 \
+	| paste $BPS - \
+	| cut -f 4,13- > ${OPATH}${ESTUB}.expression.tpm.matrix
 	
 ## TPM normalize each strand separately
 for STRAND in minus plus; do
 	for SIDE in left right; do
-		${BINDIR}/tpm_transform.pl ${TEMP}${ESTUB}.expression.${SIDE}.${STRAND}.matrix ${LIBRARYCOUNTS} 1 | paste $BPS - | cut -f 4,13- > ${TEMP}${ESTUB}.expression.${SIDE}.${STRAND}.tpm.matrix
+		${BINDIR}/tpm_transform.pl ${TEMP}${ESTUB}.expression.${SIDE}.${STRAND}.matrix ${LIBRARYCOUNTS} 1 \
+			| paste $BPS - \
+			| cut -f 4,13- > ${TEMP}${ESTUB}.expression.${SIDE}.${STRAND}.tpm.matrix
 	done
 done
 
@@ -228,12 +245,23 @@ for STRAND in minus plus; do
 		awk '{s=0; for (i=2; i<=NF; i++) {if ($i != "NA") s+=$i}; print s}' ${TEMP}${ESTUB}.expression.${SIDE}.${STRAND}.tpm.matrix > ${TEMP}${ESTUB}.expression.${SIDE}.${STRAND}.tpm.sum
 	done
 done
-paste ${TEMP}${ESTUB}.expression.right.plus.tpm.sum ${TEMP}${ESTUB}.expression.left.minus.tpm.sum | awk '{print ($1 == "NA" || ($1+$2 == 0)) ? "NA" : ($1-$2) / ($1+$2)}' | paste $BPS - | cut -f 4,13 > ${OPATH}${ESTUB}.directionality.txt
-paste ${TEMP}${ESTUB}.expression.left.plus.tpm.sum ${TEMP}${ESTUB}.expression.left.minus.tpm.sum | awk '{print ($1 == "NA" || $2 == 0) ? "NA" : $1 / $2}' | paste $BPS - | cut -f 4,13 > ${TEMP}${ESTUB}.left.plus.fraction.txt
-paste ${TEMP}${ESTUB}.expression.right.minus.tpm.sum ${TEMP}${ESTUB}.expression.right.plus.tpm.sum | awk '{print ($1 == "NA" || $2 == 0) ? "NA" : $1 / $2}' | paste $BPS - | cut -f 4,13 > ${TEMP}${ESTUB}.right.minus.fraction.txt
+paste ${TEMP}${ESTUB}.expression.right.plus.tpm.sum ${TEMP}${ESTUB}.expression.left.minus.tpm.sum \
+	| awk '{print ($1 == "NA" || ($1+$2 == 0)) ? "NA" : ($1-$2) / ($1+$2)}' \
+	| paste $BPS - \
+	| cut -f 4,13 > ${OPATH}${ESTUB}.directionality.txt
+paste ${TEMP}${ESTUB}.expression.left.plus.tpm.sum ${TEMP}${ESTUB}.expression.left.minus.tpm.sum \
+	| awk '{print ($1 == "NA" || $2 == 0) ? "NA" : $1 / $2}' \
+	| paste $BPS - \
+	| cut -f 4,13 > ${TEMP}${ESTUB}.left.plus.fraction.txt
+paste ${TEMP}${ESTUB}.expression.right.minus.tpm.sum ${TEMP}${ESTUB}.expression.right.plus.tpm.sum \
+	| awk '{print ($1 == "NA" || $2 == 0) ? "NA" : $1 / $2}' \
+	| paste $BPS - \
+	| cut -f 4,13 > ${TEMP}${ESTUB}.right.minus.fraction.txt
 
 ## Calculate directionality matrix
-${BINDIR}/matrix_directionality.pl ${TEMP}${ESTUB}.expression.right.plus.tpm.matrix ${TEMP}${ESTUB}.expression.left.minus.tpm.matrix 1 | paste $BPS - | cut -f 4,13- > ${OPATH}${ESTUB}.directionality.matrix
+${BINDIR}/matrix_directionality.pl ${TEMP}${ESTUB}.expression.right.plus.tpm.matrix ${TEMP}${ESTUB}.expression.left.minus.tpm.matrix 1 \
+	| paste $BPS - \
+	| cut -f 4,13- > ${OPATH}${ESTUB}.directionality.matrix
 
 ## Check if bidirectionally transcribed in at least one sample
 ${BINDIR}/matrix_bidirectional_transcribed.pl ${TEMP}${ESTUB}.expression.left.minus.matrix ${TEMP}${ESTUB}.expression.right.plus.matrix 1 > ${TEMP}${ESTUB}.bidir.transcribed.txt
@@ -243,7 +271,9 @@ echoerr "Predicting enhancers"
 cut -f 2 ${TEMP}${ESTUB}.left.plus.fraction.txt > ${TEMP}${ESTUB}.lp.txt
 cut -f 2 ${TEMP}${ESTUB}.right.minus.fraction.txt > ${TEMP}${ESTUB}.rm.txt
 cut -f 2 ${OPATH}${ESTUB}.directionality.txt > ${TEMP}${ESTUB}.wdir.txt
-paste $BPS ${TEMP}${ESTUB}.lp.txt ${TEMP}${ESTUB}.rm.txt ${TEMP}${ESTUB}.wdir.txt ${TEMP}${ESTUB}.bidir.transcribed.txt | awk -v dir=$DIR '{if ($13 < 1 && $14 < 1 && $15 < dir && $15 > (-1*dir) && $16 == 1) print $0}' | cut -f -12 > ${OPATH}${STUB}enhancers.bed
+paste $BPS ${TEMP}${ESTUB}.lp.txt ${TEMP}${ESTUB}.rm.txt ${TEMP}${ESTUB}.wdir.txt ${TEMP}${ESTUB}.bidir.transcribed.txt \
+	| awk -v dir=$DIR '{if ($13 < 1 && $14 < 1 && $15 < dir && $15 > (-1*dir) && $16 == 1) print $0}' \
+	| cut -f -12 > ${OPATH}${STUB}enhancers.bed
 
 sort --temporary-directory=${TEMP} -k 4,4 -o $BPS $BPS
 sort --temporary-directory=${TEMP} -k 1,1 -o ${OPATH}${ESTUB}.expression.matrix ${OPATH}${ESTUB}.expression.matrix
@@ -251,7 +281,11 @@ sort --temporary-directory=${TEMP} -k 1,1 -o ${OPATH}${ESTUB}.expression.tpm.mat
 sort --temporary-directory=${TEMP} -k 1,1 -o ${OPATH}${ESTUB}.directionality.txt ${OPATH}${ESTUB}.directionality.txt
 sort --temporary-directory=${TEMP} -k 1,1 -o ${OPATH}${ESTUB}.directionality.matrix ${OPATH}${ESTUB}.directionality.matrix
 sort --temporary-directory=${TEMP} -k 4,4 -o ${OPATH}${STUB}enhancers.bed ${OPATH}${STUB}enhancers.bed
-cut -f 4 ${OPATH}${STUB}enhancers.bed | join -1 1 -2 1 - ${OPATH}${ESTUB}.expression.matrix | tr " " "\t" > ${OPATH}${STUB}enhancer.expression.matrix
-cut -f 4 ${OPATH}${STUB}enhancers.bed | join -1 1 -2 1 - ${OPATH}${ESTUB}.expression.tpm.matrix | tr " " "\t" > ${OPATH}${STUB}enhancer.expression.tpm.matrix
+cut -f 4 ${OPATH}${STUB}enhancers.bed \
+	| join -1 1 -2 1 - ${OPATH}${ESTUB}.expression.matrix \
+	| tr " " "\t" > ${OPATH}${STUB}enhancer.expression.matrix
+cut -f 4 ${OPATH}${STUB}enhancers.bed \
+	| join -1 1 -2 1 - ${OPATH}${ESTUB}.expression.tpm.matrix \
+	| tr " " "\t" > ${OPATH}${STUB}enhancer.expression.tpm.matrix
 
 if [ $RMTMP -eq 1 ]; then rm -rf $TEMP; fi


### PR DESCRIPTION
Fixes #1 
This is a few changes in "bidir_enhancers".
bedtools merge -scores is now deprecated. I was changed from "-scores" to "-o" and added to "-S +/-" in each strand separation process.
According to this change, TCFILE values and split_strand.pl were not needed in this pipeline.
Please review these two strings.

Suimye